### PR TITLE
Send payload+fin in one go

### DIFF
--- a/src/network/tcp-socket.ts
+++ b/src/network/tcp-socket.ts
@@ -98,14 +98,12 @@ export default class TcpSocket extends TplinkSocket {
           const actualResponseLen = deviceDataBuf.length - 4;
 
           if (actualResponseLen >= expectedResponseLen) {
-            setSocketTimeout(0);
             decryptedMsg = decrypt(deviceDataBuf.slice(4)).toString('utf8');
             this.logDebug(
               `: socket:data: segment:${segmentCount} ${actualResponseLen}/${expectedResponseLen} [${replaceControlCharacters(
                 decryptedMsg
               )}]`
             );
-            socket.end();
           } else {
             this.logDebug(
               `: socket:data: segment:${segmentCount} ${actualResponseLen}/${expectedResponseLen} ...`
@@ -171,11 +169,8 @@ export default class TcpSocket extends TplinkSocket {
             `: socket:connect ${socket.localAddress} ${socket.localPort} ${socket.remoteAddress} ${socket.remotePort}`
           );
           this.isBound = true;
-          const writeRet = socket.write(encryptedPayload);
-          this.logDebug(
-            ': socket:connect:write',
-            writeRet ? 'flushed' : 'queued'
-          );
+          socket.end(encryptedPayload);
+          this.logDebug(': socket:connect:end');
         } catch (err) {
           this.logDebug(': socket:connect error');
           reject(err);


### PR DESCRIPTION
Send the payload using socket.end so we immediately close our end of the connection (we're not sending anything else afterwards). This doesn't stop us from receiving the reply (the connection is half-closed).  The device calls are much faster this way. 
Also, don't clear the timeout when we get the reply, but wait until we get the close event. This stops the connection hanging if the remote end fails to shutdown the TCP connection correctly (which seems to happen occasionally with some devices).